### PR TITLE
feat(dashboard): add all-account quota overview

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 PLUGIN_ID := cpa-quota-estimator
-VERSION ?= 0.4.6
+VERSION ?= 0.5.0
 GOOS ?= $(shell go env GOOS)
 GOARCH ?= $(shell go env GOARCH)
 EXT := so

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ plugin registered plugin_id=cpa-quota-estimator plugin_name=CPA Quota Estimator
 
 Open **额度容量预测 / Quota Estimator** from CPAMP. The dashboard first tries the authenticated plugin bridge. If the bridge is unavailable in a same-origin deployment, it can reuse the Management Key already persisted by CPAMP's **Remember password** option. Cross-origin deployments and non-persisted CPAMP sessions fall back to CPA Management Key login. Enable **Remember the key in this browser** there to keep the fallback key in this browser's `localStorage`; otherwise it remains only in the current tab's `sessionStorage`. Do not enable persistent storage on a shared device.
 
-> **Cold start:** Installing the plugin does not immediately show your quota. The plugin is completely passive — it only records requests that actually flow through CPA and cannot reconstruct usage that happened before installation. The current quota percentage and reset time appear only after the first real Codex request, and capacity estimates start only once quota usage actually grows between recorded samples (Δquota_percent > 0). Because quota headers report integer percentages, the first usable estimate may take several requests, and results stabilize as consumption accumulates.
+> **Cold start:** Installing the plugin does not immediately show quota samples. The plugin is completely passive — it only records requests that actually flow through CPA and cannot reconstruct usage that happened before installation. The all-account overview attempts to merge configured Codex OAuth credentials from CPA's protected `auth-files` management endpoint; credentials that have not yet passed a request through CPA are shown as awaiting their first sample instead of appearing to be missing. Current remaining quota and reset time appear after the first real Codex request, and capacity estimates start only once the recorded used percentage grows between samples (`delta used percentage > 0`). Because quota headers report integer percentages, the first usable estimate may take several requests, and results stabilize as consumption accumulates.
 
 Plugin upgrades migrate the SQLite schema in place and do not intentionally clear usage history. Upgrading does not automatically rewrite historical cycles. Historical false early resets are changed only through the explicit repair POST described below. In Docker, persist the directory containing `data_path`—the default is `/CLIProxyAPI/data`—with a volume or bind mount; replacing a container without that mount also replaces its local database.
 
@@ -152,6 +152,7 @@ All management routes are protected by CPA Management Key:
 
 | Method | Path | Purpose |
 |---|---|---|
+| GET | `/v0/management/cpa-quota-estimator/overview` | Current primary-quota forecast overview for every recorded account |
 | GET | `/v0/management/cpa-quota-estimator/summary` | Selected quota-cycle and forecast summary |
 | GET | `/v0/management/cpa-quota-estimator/series` | Selected quota-cycle chart samples |
 | GET | `/v0/management/cpa-quota-estimator/monthly` | Calendar-month usage, reset, and capacity summary |
@@ -160,6 +161,8 @@ All management routes are protected by CPA Management Key:
 | GET | `/v0/management/cpa-quota-estimator/prices` | Synced prices and Fast policy |
 | POST | `/v0/management/cpa-quota-estimator/prices/sync` | Trigger an immediate models.dev sync |
 | GET | `/v0/resource/plugins/cpa-quota-estimator/dashboard` | Embedded dashboard resource |
+
+`overview` returns one lightweight current-cycle record per sampled account, including plan type, remaining quota, requests, Tokens, USD-equivalent cost, full-cycle Token/USD capacity estimates, confidence, and burn forecast. The dashboard also reads CPA's Codex OAuth inventory and merges credentials without samples into the same table. The overview can be collapsed, every column has its own client-side filter, and selecting a column heading toggles type-aware ascending/descending sorting. Drag a heading boundary to resize that column from the 40 px technical minimum up to 2000 px, or double-click the resize handle to restore its default width; keyboard users can focus the separator and use the arrow keys (`Shift` for a larger step) or `Home` to reset it. Number and time filters accept `>`, `>=`, `<`, `<=`, and `=` comparisons; view preferences and column widths persist in the current browser. Selecting a sampled row opens that account in the existing detailed view without issuing AI requests. If neither the restricted parent bridge nor a reusable Management Key can read the inventory, sampled accounts remain available and the dashboard explicitly reports that the OAuth inventory is unavailable.
 
 Use `?account=<AuthID>` to select a credential, `?cycle_id=<ID>` on `summary` or `series` to select the forecast cycle, and `?month=YYYY-MM` on `monthly` to select a month. On `series`, pass Unix-second `?start_at=<timestamp>&end_at=<timestamp>` values to return chart samples and capacity trajectories across every quota cycle overlapping that range.
 
@@ -174,7 +177,7 @@ Requires Go 1.22+, GCC, and CGO:
 ```bash
 make test
 make build
-make package VERSION=0.4.6
+make package VERSION=0.5.0
 ```
 
 `make package` produces a marketplace-compatible zip and `checksums.txt` under `dist/`. Tagged releases are built for Linux amd64/arm64, macOS amd64/arm64, and Windows amd64 by GitHub Actions.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -126,7 +126,7 @@ plugin registered plugin_id=cpa-quota-estimator plugin_name=CPA Quota Estimator
 
 在 CPAMP 中打开**额度容量预测 / Quota Estimator**。仪表盘会优先复用已认证的插件桥接；同源部署且桥接不可用时，也会自动复用 CPAMP 通过**记住密码**选项持久保存的 Management Key。跨域部署或 CPAMP 未持久保存登录态时，才回退到 CPA Management Key 登录。此时勾选**在此浏览器记住密钥**后，兜底密钥会保存在当前浏览器的 `localStorage` 中；不勾选则仍只保存在当前标签页的 `sessionStorage` 中。共享设备请勿开启持久保存。
 
-> **冷启动说明：** 安装插件后并不会立即看到额度。插件完全被动，只记录真实流经 CPA 的请求，也无法回补安装之前的历史用量。首次真实的 Codex 请求之后，才会出现当前额度百分比和重置时间；只有当记录样本之间的额度百分比确实增长（Δ额度百分比 > 0）时，才开始计算容量估算。由于额度响应头只提供整数百分比，首个可用估算可能需要多次请求才会出现，并随着消耗累积逐渐稳定。
+> **冷启动说明：** 安装插件后并不会立即看到额度。插件完全被动，只记录真实流经 CPA 的请求，也无法回补安装之前的历史用量。全部账号概览会尝试从受保护的 CPA `auth-files` 管理接口合并已配置的 Codex OAuth；尚未流经 CPA 的账号会显示为“等待首次经 CPA 调用”，而不是被误判为凭证丢失。首次真实的 Codex 请求之后，才会出现当前剩余额度和重置时间；只有当记录样本之间的已使用额度百分比确实增长（Δ已使用百分比 > 0）时，才开始计算容量估算。由于额度响应头只提供整数百分比，首个可用估算可能需要多次请求才会出现，并随着消耗累积逐渐稳定。
 
 插件升级会原位迁移 SQLite 表结构，不会主动清空历史用量，也不会自动改写历史周期。历史伪提前重置只有在显式调用下述修复 POST 后才会变更。使用 Docker 时，应通过 volume 或 bind mount 持久化 `data_path` 所在目录；默认目录是 `/CLIProxyAPI/data`。如果替换容器时没有挂载该目录，容器内的本地数据库也会随之被替换。
 
@@ -152,6 +152,7 @@ Token 图表使用输入 Token 与输出 Token 之和。缓存 Token 通常已�
 
 | 方法 | 路径 | 用途 |
 |---|---|---|
+| GET | `/v0/management/cpa-quota-estimator/overview` | 所有已记录账号的当前主额度预测概览 |
 | GET | `/v0/management/cpa-quota-estimator/summary` | 所选额度周期与预测摘要 |
 | GET | `/v0/management/cpa-quota-estimator/series` | 所选额度周期图表采样数据 |
 | GET | `/v0/management/cpa-quota-estimator/monthly` | 自然月用量、重置与容量汇总 |
@@ -160,6 +161,8 @@ Token 图表使用输入 Token 与输出 Token 之和。缓存 Token 通常已�
 | GET | `/v0/management/cpa-quota-estimator/prices` | 已同步价格与 Fast 策略 |
 | POST | `/v0/management/cpa-quota-estimator/prices/sync` | 立即触发 models.dev 价格同步 |
 | GET | `/v0/resource/plugins/cpa-quota-estimator/dashboard` | 嵌入式仪表盘资源 |
+
+`overview` 为每个已采样账号返回一条轻量的当前周期记录，包括计划类型、当前剩余额度、请求数、Token、美元等价费用、完整周期 Token/USD 容量估计、置信度和消耗预测。仪表盘还会只读查询 CPA 的 Codex OAuth 清单，把未采样账号合并进同一张表格。概览支持折叠；每一列都有独立的浏览器端筛选框，点击列名可按字段类型切换升序/降序。拖动表头列边界可在 `40px` 技术下限至 `2000px` 之间调整列宽，双击拖动手柄可恢复该列默认宽度；键盘用户可聚焦分隔条后使用方向键调整（按住 `Shift` 增大步长），或按 `Home` 重置。数字和时间筛选支持 `>`、`>=`、`<`、`<=`、`=` 比较符，显示偏好和列宽会保存在当前浏览器。点击有样本的账号行即可进入现有详情视图，整个过程不会发起 AI 请求。若父面板未提供受限桥接且浏览器没有可复用的 Management Key，仪表盘仍会正常展示已采样账号，并明确提示 OAuth 清单暂不可读。
 
 使用 `?account=<AuthID>` 可选择指定凭证；在 `summary` 或 `series` 中使用 `?cycle_id=<ID>` 可选择预测周期；在 `monthly` 中使用 `?month=YYYY-MM` 可选择月份。`series` 还可传入 Unix 秒级的 `?start_at=<时间戳>&end_at=<时间戳>`，返回该范围内所有重叠额度周期的曲线采样点和容量估计轨迹。
 
@@ -174,7 +177,7 @@ Token 图表使用输入 Token 与输出 Token 之和。缓存 Token 通常已�
 ```bash
 make test
 make build
-make package VERSION=0.4.6
+make package VERSION=0.5.0
 ```
 
 `make package` 会在 `dist/` 下生成兼容插件商店的压缩包和 `checksums.txt`。带版本标签的发布会通过 GitHub Actions 构建 Linux amd64/arm64、macOS amd64/arm64 和 Windows amd64 版本。

--- a/api.go
+++ b/api.go
@@ -29,6 +29,42 @@ func (a *app) handleManagement(req managementRequest) managementResponse {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 	switch {
+	case strings.HasSuffix(req.Path, "/overview"):
+		accounts, err := a.store.accounts(ctx)
+		if err != nil {
+			return textResponse(500, err.Error())
+		}
+		items := make([]accountOverview, 0, len(accounts))
+		now := time.Now().Unix()
+		for _, account := range accounts {
+			item := accountOverview{Account: account}
+			cycles, errCycles := a.store.cycles(ctx, account, 1)
+			if errCycles != nil {
+				return textResponse(500, errCycles.Error())
+			}
+			if len(cycles) == 0 {
+				items = append(items, item)
+				continue
+			}
+			selected := cycles[0]
+			points, plan, errPoints := a.store.pointsForCycle(ctx, account, selected.ID, 5000)
+			if errPoints != nil && errPoints != sql.ErrNoRows {
+				return textResponse(500, errPoints.Error())
+			}
+			item.PlanType = plan
+			item.SelectedCycleID = selected.ID
+			item.WindowStart = selected.StartedAt
+			item.IsCurrent = selected.Current
+			item.Estimate = estimateCapacity(points)
+			item.BurnForecast = estimateBurn(points, forecastReference(points, selected.Current))
+			if len(points) > 0 {
+				latest := points[len(points)-1]
+				item.RemainingPercent, item.QuotaStatus = quotaSnapshotState(latest, now)
+				item.Latest = &latest
+			}
+			items = append(items, item)
+		}
+		return jsonResponse(200, overviewResponse{PluginVersion: pluginVersion, Accounts: items})
 	case strings.HasSuffix(req.Path, "/summary"):
 		account := req.Query.Get("account")
 		accounts, err := a.store.accounts(ctx)
@@ -62,7 +98,9 @@ func (a *app) handleManagement(req managementRequest) managementResponse {
 			resp["estimate"] = estimateCapacity(points)
 			resp["burn_forecast"] = estimateBurn(points, forecastReference(points, isCurrent))
 			if len(points) > 0 {
-				resp["latest"] = points[len(points)-1]
+				latest := points[len(points)-1]
+				resp["latest"] = latest
+				resp["remaining_percent"], resp["quota_status"] = quotaSnapshotState(latest, time.Now().Unix())
 				resp["window_start"] = selected.StartedAt
 			}
 		}
@@ -200,4 +238,16 @@ func forecastReference(points []quotaPoint, isCurrent bool) int64 {
 		return time.Now().Unix()
 	}
 	return points[len(points)-1].Time
+}
+
+func quotaSnapshotState(point quotaPoint, now int64) (float64, string) {
+	used := max(float64(0), min(float64(100), point.UsedPercent))
+	remaining := 100 - used
+	if remaining <= 0.5 {
+		return remaining, "exhausted"
+	}
+	if point.ResetAt > 0 && now >= point.ResetAt {
+		return remaining, "awaiting_refresh"
+	}
+	return remaining, "active"
 }

--- a/api_test.go
+++ b/api_test.go
@@ -1,0 +1,134 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net/url"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestOverviewReturnsEveryRecordedAccount(t *testing.T) {
+	s, err := openStore(filepath.Join(t.TempDir(), "overview.sqlite"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.close()
+
+	now := time.Now().Unix()
+	resetAt := ((now + 5*24*60*60 + 30) / 60) * 60
+	seedOverviewAccount(t, s, "team-account", "team", now-3600, resetAt, []float64{10, 14})
+	seedOverviewAccount(t, s, "k12-account", "k12", now-3000, resetAt, []float64{95, 100})
+
+	a := &app{cfg: defaultConfig(), store: s}
+	response := a.handleManagement(managementRequest{
+		Method: "GET",
+		Path:   "/cpa-quota-estimator/overview",
+		Query:  url.Values{},
+	})
+	if response.StatusCode != 200 {
+		t.Fatalf("status=%d body=%s", response.StatusCode, response.Body)
+	}
+	var overview overviewResponse
+	if err = json.Unmarshal(response.Body, &overview); err != nil {
+		t.Fatal(err)
+	}
+	if overview.PluginVersion != pluginVersion {
+		t.Fatalf("plugin_version=%q want %q", overview.PluginVersion, pluginVersion)
+	}
+	if len(overview.Accounts) != 2 {
+		t.Fatalf("accounts=%d want 2", len(overview.Accounts))
+	}
+	byAccount := make(map[string]accountOverview, len(overview.Accounts))
+	for _, item := range overview.Accounts {
+		byAccount[item.Account] = item
+	}
+	for account, plan := range map[string]string{"team-account": "team", "k12-account": "k12"} {
+		item, ok := byAccount[account]
+		if !ok {
+			t.Fatalf("missing account %q", account)
+		}
+		if item.PlanType != plan || item.Latest == nil {
+			t.Fatalf("account=%q plan=%q latest=%v", account, item.PlanType, item.Latest)
+		}
+		if item.Latest.Requests != 2 || item.Latest.WindowTokens != 3000 {
+			t.Fatalf("account=%q requests=%d tokens=%d", account, item.Latest.Requests, item.Latest.WindowTokens)
+		}
+		if !item.Estimate.Available || !item.BurnForecast.Available {
+			t.Fatalf("account=%q estimate=%+v burn=%+v", account, item.Estimate, item.BurnForecast)
+		}
+	}
+	if got := byAccount["team-account"]; got.RemainingPercent != 86 || got.QuotaStatus != "active" {
+		t.Fatalf("team snapshot remaining=%v status=%q", got.RemainingPercent, got.QuotaStatus)
+	}
+	if got := byAccount["k12-account"]; got.RemainingPercent != 0 || got.QuotaStatus != "exhausted" {
+		t.Fatalf("k12 snapshot remaining=%v status=%q", got.RemainingPercent, got.QuotaStatus)
+	}
+}
+
+func TestQuotaSnapshotState(t *testing.T) {
+	now := time.Now().Unix()
+	for _, test := range []struct {
+		name      string
+		point     quotaPoint
+		remaining float64
+		status    string
+	}{
+		{name: "active", point: quotaPoint{UsedPercent: 20, ResetAt: now + 60}, remaining: 80, status: "active"},
+		{name: "exhausted", point: quotaPoint{UsedPercent: 100, ResetAt: now + 60}, remaining: 0, status: "exhausted"},
+		{name: "stale after reset", point: quotaPoint{UsedPercent: 75, ResetAt: now - 1}, remaining: 25, status: "awaiting_refresh"},
+		{name: "clamps invalid percent", point: quotaPoint{UsedPercent: 120, ResetAt: now + 60}, remaining: 0, status: "exhausted"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			remaining, status := quotaSnapshotState(test.point, now)
+			if remaining != test.remaining || status != test.status {
+				t.Fatalf("remaining=%v status=%q want remaining=%v status=%q", remaining, status, test.remaining, test.status)
+			}
+		})
+	}
+}
+
+func TestOverviewReturnsEmptyArrayWithoutSamples(t *testing.T) {
+	s, err := openStore(filepath.Join(t.TempDir(), "empty-overview.sqlite"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer s.close()
+	a := &app{cfg: defaultConfig(), store: s}
+	response := a.handleManagement(managementRequest{Method: "GET", Path: "/cpa-quota-estimator/overview", Query: url.Values{}})
+	if response.StatusCode != 200 {
+		t.Fatalf("status=%d body=%s", response.StatusCode, response.Body)
+	}
+	var raw map[string]json.RawMessage
+	if err = json.Unmarshal(response.Body, &raw); err != nil {
+		t.Fatal(err)
+	}
+	if string(raw["accounts"]) != "[]" {
+		t.Fatalf("accounts=%s want []", raw["accounts"])
+	}
+}
+
+func seedOverviewAccount(t *testing.T, s *store, account, plan string, startedAt, resetAt int64, usedValues []float64) {
+	t.Helper()
+	for index, used := range usedValues {
+		usedCopy := used
+		at := startedAt + int64(index)*600
+		err := s.insertEvent(context.Background(), event{
+			RequestedAt:   at,
+			ObservedAt:    at,
+			Account:       account,
+			Provider:      "openai",
+			Model:         "gpt-test",
+			TotalTokens:   int64(index+1) * 1000,
+			CostUSD:       float64(index + 1),
+			UsedPercent:   &usedCopy,
+			ResetAt:       resetAt,
+			WindowMinutes: 10080,
+			PlanType:      plan,
+		}, time.Minute)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+}

--- a/app.go
+++ b/app.go
@@ -77,6 +77,7 @@ func managementRegistration() any {
 	base := "/" + pluginID
 	return map[string]any{
 		"routes": []map[string]any{
+			{"Method": "GET", "Path": base + "/overview"},
 			{"Method": "GET", "Path": base + "/summary"},
 			{"Method": "GET", "Path": base + "/series"},
 			{"Method": "GET", "Path": base + "/monthly"},

--- a/app_test.go
+++ b/app_test.go
@@ -1,11 +1,33 @@
 package main
 
 import (
+	"bytes"
 	"net/http"
 	"path/filepath"
 	"testing"
 	"time"
 )
+
+func TestDashboardShowsRemainingQuotaAndExhaustedState(t *testing.T) {
+	for _, expected := range [][]byte{
+		[]byte("当前剩余额度"),
+		[]byte("overviewExhausted"),
+		[]byte("overviewAwaitingFirstSample"),
+		[]byte("loadConfiguredCodexAccounts"),
+		[]byte("overviewCapacityCost"),
+		[]byte("overviewToggle"),
+		[]byte("data-overview-filter"),
+		[]byte("compareOverviewRows"),
+		[]byte("cqe-overview-preferences-v1"),
+		[]byte("setupOverviewColumnResizers"),
+		[]byte("overview-column-resizer"),
+		[]byte("overview-toggle-icon"),
+	} {
+		if !bytes.Contains(dashboardHTML, expected) {
+			t.Fatalf("dashboard is missing %q", expected)
+		}
+	}
+}
 
 func TestManagementRegistrationIncludesAllHandledRoutes(t *testing.T) {
 	registration := managementRegistration().(map[string]any)
@@ -16,6 +38,7 @@ func TestManagementRegistrationIncludesAllHandledRoutes(t *testing.T) {
 	}
 
 	for _, expected := range []string{
+		"GET /cpa-quota-estimator/overview",
 		"GET /cpa-quota-estimator/summary",
 		"GET /cpa-quota-estimator/series",
 		"GET /cpa-quota-estimator/monthly",

--- a/docs/CPAMP_AUTH_BRIDGE.md
+++ b/docs/CPAMP_AUTH_BRIDGE.md
@@ -22,7 +22,7 @@ CPA 插件资源运行在 iframe 中，默认无法继承 CPAMP 内存中的 Man
 - 响应消息类型：`cpamp:plugin-api-response`
 - 只接受当前插件 iframe 的 `event.source` 和相同 `origin`。
 - 只允许 `GET`、`POST`。
-- 路径必须以 `/v0/management/<当前 pluginID>/` 开头。
+- 常规路径必须以 `/v0/management/<当前 pluginID>/` 开头。额度预测插件还可只读请求精确路径 `GET /v0/management/auth-files`，父页面必须先把响应裁剪为 `id`、`name`、`type/provider`、`account_type`、`disabled` 和 `unavailable`，不得把 ID Token、邮箱、项目 ID 或其他凭证元数据传入 iframe。
 - 父页面调用 `apiClient.get` 或 `apiClient.post` 时，要去掉路径开头的 `/v0/management`，因为 `apiClient` 的 `baseURL` 已包含该前缀。否则会请求到重复路径 `/v0/management/v0/management/...`。
 - 返回状态码与 JSON 数据，不返回或传递管理员密钥。
 

--- a/estimator_test.go
+++ b/estimator_test.go
@@ -71,6 +71,34 @@ func TestEstimateCapacity(t *testing.T) {
 	}
 }
 
+func TestEstimateCapacityUsesDeltaAfterFirstObservation(t *testing.T) {
+	points := []quotaPoint{
+		{Time: 1000, UsedPercent: 20, WindowTokens: 1_000_000, WindowCostUSD: 1},
+		{Time: 2000, UsedPercent: 50, WindowTokens: 4_000_000, WindowCostUSD: 4},
+	}
+	estimate := estimateCapacity(points)
+	if estimate.PercentSpan != 30 || estimate.FullWindowTokens != 10_000_000 || estimate.FullWindowCostUSD != 10 {
+		t.Fatalf("delta-based estimate = %#v", estimate)
+	}
+	if estimate.RemainingTokens != 5_000_000 || estimate.RemainingCostUSD != 5 {
+		t.Fatalf("remaining estimate = %#v", estimate)
+	}
+}
+
+func TestEstimateCapacityIsLowerWhenUntrackedUsageExpandsQuotaDelta(t *testing.T) {
+	trackedOnly := estimateCapacity([]quotaPoint{
+		{Time: 1000, UsedPercent: 20, WindowTokens: 1_000_000},
+		{Time: 2000, UsedPercent: 50, WindowTokens: 4_000_000},
+	})
+	withUntrackedUsage := estimateCapacity([]quotaPoint{
+		{Time: 1000, UsedPercent: 20, WindowTokens: 1_000_000},
+		{Time: 2000, UsedPercent: 80, WindowTokens: 4_000_000},
+	})
+	if trackedOnly.FullWindowTokens != 10_000_000 || withUntrackedUsage.FullWindowTokens != 5_000_000 {
+		t.Fatalf("tracked=%#v with untracked usage=%#v", trackedOnly, withUntrackedUsage)
+	}
+}
+
 func TestEstimateCapacityUsesFirstMonotonicCrossings(t *testing.T) {
 	points := []quotaPoint{
 		{Time: 1000, UsedPercent: 10, ResetAt: 9000, WindowTokens: 100, WindowCostUSD: 10},

--- a/patches/cpamp-plugin-auth-bridge.patch
+++ b/patches/cpamp-plugin-auth-bridge.patch
@@ -56,7 +56,13 @@ index 051f035..149fb5c 100644
 +        return;
 +      }
 +      const allowedPrefix = `/v0/management/${pluginID}/`;
-+      if (parsed.origin !== window.location.origin || !parsed.pathname.startsWith(allowedPrefix)) {
++      const isPluginRoute = parsed.pathname.startsWith(allowedPrefix);
++      const isQuotaAuthInventory =
++        pluginID === 'cpa-quota-estimator' &&
++        method === 'GET' &&
++        parsed.pathname === '/v0/management/auth-files' &&
++        parsed.search === '';
++      if (parsed.origin !== window.location.origin || (!isPluginRoute && !isQuotaAuthInventory)) {
 +        frameWindow.postMessage(
 +          { type: PLUGIN_API_RESPONSE, id, status: 403, data: { error: 'plugin route denied' } },
 +          event.origin
@@ -66,10 +72,28 @@ index 051f035..149fb5c 100644
 +
 +      try {
 +        const managementPath = `${parsed.pathname.slice('/v0/management'.length)}${parsed.search}`;
-+        const data =
-+          method === 'POST'
-+            ? await apiClient.post(managementPath, event.data.body)
-+            : await apiClient.get(managementPath);
++        let data;
++        if (isQuotaAuthInventory) {
++          const inventory = (await apiClient.get(managementPath)) as {
++            files?: Array<Record<string, unknown>>;
++          };
++          data = {
++            files: (inventory.files || []).map((file) => ({
++              id: file.id,
++              name: file.name,
++              type: file.type,
++              provider: file.provider,
++              account_type: file.account_type,
++              disabled: file.disabled,
++              unavailable: file.unavailable,
++            })),
++          };
++        } else {
++          data =
++            method === 'POST'
++              ? await apiClient.post(managementPath, event.data.body)
++              : await apiClient.get(managementPath);
++        }
 +        frameWindow.postMessage({ type: PLUGIN_API_RESPONSE, id, status: 200, data }, event.origin);
 +      } catch (error) {
 +        frameWindow.postMessage(

--- a/types.go
+++ b/types.go
@@ -12,7 +12,7 @@ const (
 	pluginName = "CPA Quota Estimator"
 )
 
-var pluginVersion = "0.4.6"
+var pluginVersion = "0.5.0"
 
 type envelope struct {
 	OK     bool            `json:"ok"`
@@ -273,6 +273,24 @@ type burnForecast struct {
 	RecentEstimatedExhaustAt int64   `json:"recent_estimated_exhaust_at,omitempty"`
 	RecentWillExhaustBefore  bool    `json:"recent_will_exhaust_before_reset"`
 	Status                   string  `json:"status"`
+}
+
+type accountOverview struct {
+	Account          string       `json:"account"`
+	PlanType         string       `json:"plan_type"`
+	SelectedCycleID  int64        `json:"selected_cycle_id,omitempty"`
+	WindowStart      int64        `json:"window_start,omitempty"`
+	IsCurrent        bool         `json:"is_current"`
+	RemainingPercent float64      `json:"remaining_percent"`
+	QuotaStatus      string       `json:"quota_status"`
+	Latest           *quotaPoint  `json:"latest,omitempty"`
+	Estimate         estimate     `json:"estimate"`
+	BurnForecast     burnForecast `json:"burn_forecast"`
+}
+
+type overviewResponse struct {
+	PluginVersion string            `json:"plugin_version"`
+	Accounts      []accountOverview `json:"accounts"`
 }
 
 type monthlyCycle struct {

--- a/web/dashboard.html
+++ b/web/dashboard.html
@@ -8,18 +8,22 @@
 :root.theme-light,:root[data-theme="white"]{color-scheme:light;--bg:#eff2f7;--glow:#dceaff;--panel-start:rgba(255,255,255,.99);--panel-end:rgba(248,250,253,.99);--control:#fff;--line:rgba(15,23,42,.1);--grid:#dce2ea;--text:#263445;--muted:#718096;--primary-bg:#3578e5;--primary-text:#fff;--login-bg:#fff;--overlay:rgba(225,231,240,.84);--green:#1f9d61;--blue:#3478e5;--amber:#c57a12;--purple:#7957c7;--red:#dc4c55}
 @media(prefers-color-scheme:light){:root:not(.theme-dark){color-scheme:light;--bg:#eff2f7;--glow:#dceaff;--panel-start:rgba(255,255,255,.99);--panel-end:rgba(248,250,253,.99);--control:#fff;--line:rgba(15,23,42,.1);--grid:#dce2ea;--text:#263445;--muted:#718096;--primary-bg:#3578e5;--primary-text:#fff;--login-bg:#fff;--overlay:rgba(225,231,240,.84);--green:#1f9d61;--blue:#3478e5;--amber:#c57a12;--purple:#7957c7;--red:#dc4c55}}
 *{box-sizing:border-box}body{margin:0;background:radial-gradient(circle at 15% -10%,var(--glow) 0,transparent 35%),var(--bg);color:var(--text);font:14px/1.5 ui-sans-serif,system-ui,-apple-system,"PingFang SC",sans-serif}.wrap{max-width:1380px;margin:auto;padding:28px}.top{display:flex;align-items:center;justify-content:space-between;gap:16px;margin-bottom:22px}h1{font-size:24px;margin:0}h1 span{display:block;font-size:13px;color:var(--muted);font-weight:400;margin-top:3px}.actions{display:flex;gap:10px;align-items:center}button,select,input{border:1px solid var(--line);background:var(--control);color:var(--text);border-radius:9px;padding:9px 12px}button{cursor:pointer}button:hover{border-color:var(--blue)}.primary{background:var(--primary-bg);color:var(--primary-text);border-color:var(--primary-bg);font-weight:650}.grid{display:grid;grid-template-columns:repeat(4,1fr);gap:13px}.card,.chart{background:linear-gradient(150deg,var(--panel-start),var(--panel-end));border:1px solid var(--line);border-radius:14px}.card{padding:17px;min-height:124px}.label{color:var(--muted);font-size:12px}.value{font-size:29px;letter-spacing:-.8px;font-weight:680;margin:6px 0}.sub{color:var(--muted);font-size:12px}.good{color:var(--green)}.warn{color:var(--amber)}.charts{display:grid;grid-template-columns:2fr 1fr;gap:13px;margin-top:13px}.chart{padding:18px}.chart h2{font-size:14px;margin:0 0 14px}.chart svg{display:block;width:100%;height:300px;overflow:visible}#curve svg{height:520px}.capacity-history{margin-top:13px}#capacityCurve svg{height:390px}.legend{display:flex;gap:18px;flex-wrap:wrap;color:var(--muted);font-size:12px;margin-top:8px}.dot{width:8px;height:8px;border-radius:50%;display:inline-block;margin-right:6px}.details{display:grid;grid-template-columns:1fr 1fr;gap:13px;margin-top:13px}.rows{padding:5px 18px}.row{display:flex;justify-content:space-between;gap:20px;padding:12px 0;border-bottom:1px solid var(--line)}.row:last-child{border:0}.row span:first-child{color:var(--muted)}.note{margin-top:13px;color:var(--muted);border:1px dashed var(--line);padding:12px 15px;border-radius:11px}.empty{height:300px;display:grid;place-items:center;color:var(--muted)}.login{position:fixed;inset:0;display:none;place-items:center;background:var(--overlay);backdrop-filter:blur(12px);z-index:9}.login.show{display:grid}.loginbox{width:min(420px,calc(100vw - 32px));background:var(--login-bg);border:1px solid var(--line);border-radius:16px;padding:24px}.loginbox h2{margin-top:0}.loginbox input{width:100%;margin:8px 0 12px}.error{color:var(--red);min-height:21px;font-size:12px}@media(max-width:900px){.top{align-items:flex-start;flex-direction:column}.actions{width:100%;flex-wrap:wrap}.grid{grid-template-columns:1fr 1fr}.charts,.details{grid-template-columns:1fr}.wrap{padding:16px}}@media(max-width:600px){.wrap{padding:10px}.top{gap:12px;margin-bottom:14px}h1{font-size:20px}.actions{display:grid;grid-template-columns:1fr 1fr;gap:8px}.actions>#account,.actions>#period,.actions>#language{grid-column:1/-1;width:100%}.actions button{width:100%}.grid{gap:8px}.card{padding:12px;min-height:105px}.value{font-size:22px}.charts{gap:8px;margin-top:8px}.chart{padding:12px}.capacity-history,.details,.note{margin-top:8px}#curve,#capacityCurve{overflow-x:auto;-webkit-overflow-scrolling:touch}#curve svg{height:440px;min-width:720px}#capacityCurve svg{height:340px;min-width:760px}.legend{gap:8px 14px}.row{font-size:12px;gap:8px}.row b{text-align:right}}@media(max-width:370px){.grid{grid-template-columns:1fr}.actions{grid-template-columns:1fr}.actions>*{grid-column:1!important}}
-.pace-section{display:grid;grid-template-columns:minmax(0,2fr) minmax(280px,1fr);gap:13px;margin-top:13px}.pace-chart{min-width:0}.pace-stats{padding:5px 18px}.pace-stats .row b{max-width:62%;text-align:right}.pace-status{display:inline-flex;align-items:center;border-radius:999px;padding:3px 9px;font-size:11px;background:color-mix(in srgb,var(--green) 15%,transparent);color:var(--green)}.pace-status.fast{background:color-mix(in srgb,var(--amber) 15%,transparent);color:var(--amber)}.pace-status.slow{background:color-mix(in srgb,var(--blue) 15%,transparent);color:var(--blue)}#paceCurve svg{height:360px}@media(max-width:900px){.pace-section{grid-template-columns:1fr}}@media(max-width:600px){.pace-section{gap:8px;margin-top:8px}.pace-chart{padding:12px}#paceCurve{overflow-x:auto;-webkit-overflow-scrolling:touch}#paceCurve svg{height:320px;min-width:760px}.pace-stats{padding:4px 12px}}
+.pace-section{display:grid;grid-template-columns:minmax(0,2fr) minmax(280px,1fr);gap:13px;margin-top:13px}.pace-chart{min-width:0}.pace-stats{padding:5px 18px}.pace-stats .row b{max-width:62%;text-align:right}.pace-status{display:inline-flex;align-items:center;border-radius:999px;padding:3px 9px;font-size:11px;background:color-mix(in srgb,var(--green) 15%,transparent);color:var(--green)}.pace-status.fast{background:color-mix(in srgb,var(--amber) 15%,transparent);color:var(--amber)}.pace-status.slow{background:color-mix(in srgb,var(--blue) 15%,transparent);color:var(--blue)}.pace-status.exhausted{background:color-mix(in srgb,var(--red) 15%,transparent);color:var(--red)}#paceCurve svg{height:360px}@media(max-width:900px){.pace-section{grid-template-columns:1fr}}@media(max-width:600px){.pace-section{gap:8px;margin-top:8px}.pace-chart{padding:12px}#paceCurve{overflow-x:auto;-webkit-overflow-scrolling:touch}#paceCurve svg{height:320px;min-width:760px}.pace-stats{padding:4px 12px}}
 .charts>.chart{min-width:0}#capacity svg{height:245px}.capacity-bar{height:7px;border-radius:999px;background:var(--grid);overflow:hidden;margin:0 2px 14px}.capacity-bar i{display:block;height:100%;border-radius:inherit;background:linear-gradient(90deg,var(--green),var(--blue))}.capacity-meta{display:grid;grid-template-columns:1fr 1fr;gap:8px}.capacity-item{min-width:0;background:color-mix(in srgb,var(--control) 72%,transparent);border:1px solid var(--line);border-radius:10px;padding:9px 10px}.capacity-item span{display:block;color:var(--muted);font-size:11px}.capacity-item b{display:block;margin-top:3px;font-size:15px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}@media(max-width:600px){#capacity svg{height:220px}.capacity-meta{gap:6px}.capacity-item{padding:8px}.capacity-item b{font-size:14px}}
 .monthly{margin-top:13px}.section-head{display:flex;align-items:flex-start;justify-content:space-between;gap:16px}.section-head h2{margin-bottom:3px}.section-head select{min-width:130px}.monthly-grid{display:grid;grid-template-columns:repeat(4,1fr);gap:9px;margin-top:14px}.monthly-item{min-width:0;background:color-mix(in srgb,var(--control) 72%,transparent);border:1px solid var(--line);border-radius:11px;padding:11px 12px}.monthly-item span{display:block;color:var(--muted);font-size:11px}.monthly-item b{display:block;margin-top:4px;font-size:19px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}.monthly-item small{display:block;color:var(--muted);font-size:10px;margin-top:2px;min-height:15px}.coverage-note{color:var(--muted);font-size:11px;margin:10px 1px}.cycle-table-wrap{overflow-x:auto;border:1px solid var(--line);border-radius:11px}.cycle-table{width:100%;border-collapse:collapse;min-width:900px}.cycle-table th,.cycle-table td{text-align:left;padding:10px 12px;border-bottom:1px solid var(--line);white-space:nowrap}.cycle-table th{color:var(--muted);font-size:11px;font-weight:550;background:color-mix(in srgb,var(--control) 70%,transparent)}.cycle-table td{font-size:12px}.cycle-table tr:last-child td{border-bottom:0}.cycle-state{display:inline-flex;border-radius:999px;padding:2px 8px;font-size:10px;background:color-mix(in srgb,var(--blue) 14%,transparent);color:var(--blue)}.cycle-state.early{background:color-mix(in srgb,var(--amber) 15%,transparent);color:var(--amber)}.cycle-state.closed{background:color-mix(in srgb,var(--muted) 13%,transparent);color:var(--muted)}@media(max-width:900px){.monthly-grid{grid-template-columns:repeat(2,1fr)}}@media(max-width:600px){.monthly{margin-top:8px}.section-head{align-items:stretch;flex-direction:column}.section-head select{width:100%}.monthly-grid{gap:6px}.monthly-item{padding:9px}.monthly-item b{font-size:16px}}
 .loginbox .remember-key{display:flex;align-items:center;gap:8px;color:var(--muted);font-size:12px;cursor:pointer;margin-bottom:8px}.loginbox .remember-key input{width:16px;height:16px;margin:0;padding:0;flex:0 0 auto;accent-color:var(--blue)}
 .chart-range{display:flex;align-items:center;justify-content:flex-end;gap:8px;margin:0 0 13px;color:var(--muted);font-size:12px}.chart-range input{min-width:185px}.chart-range .error{min-height:0;margin-left:4px}@media(max-width:760px){.chart-range{align-items:stretch;display:grid;grid-template-columns:auto 1fr}.chart-range input{min-width:0;width:100%}.chart-range button{grid-column:2}.chart-range .error{grid-column:1/-1;margin:0}}
 .spark-toggle{display:inline-flex;align-items:center;gap:8px;cursor:pointer;color:var(--text)}.spark-toggle input{width:16px;height:16px;margin:0;padding:0;accent-color:var(--purple)}.spark-toggle-top{border:1px solid color-mix(in srgb,var(--purple) 55%,var(--line));background:color-mix(in srgb,var(--purple) 11%,var(--control));border-radius:9px;padding:8px 11px;font-weight:600;white-space:nowrap}.spark-toggle-top:hover{border-color:var(--purple)}.spark-section{margin-top:18px;padding-top:18px;border-top:2px solid color-mix(in srgb,var(--purple) 52%,var(--line))}.spark-section-head{display:flex;align-items:flex-start;justify-content:space-between;gap:16px;margin-bottom:10px}.spark-section-head h2{font-size:18px;margin:0 0 3px}.spark-quota{margin-top:9px}.spark-head{display:flex;align-items:flex-start;justify-content:space-between;gap:16px}.spark-stats{display:grid;grid-template-columns:repeat(4,minmax(118px,1fr));gap:9px;margin-top:14px}.spark-stat{min-width:0;background:color-mix(in srgb,var(--control) 72%,transparent);border:1px solid var(--line);border-radius:10px;padding:8px 10px}.spark-stat span{display:block;color:var(--muted);font-size:10px}.spark-stat b{display:block;margin-top:2px;font-size:14px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}#sparkCurve svg{height:500px}@media(max-width:900px){.spark-stats{grid-template-columns:repeat(2,minmax(0,1fr))}}@media(max-width:700px){.spark-section-head,.spark-head{flex-direction:column}#sparkCurve{overflow-x:auto;-webkit-overflow-scrolling:touch}#sparkCurve svg{height:440px;min-width:760px}}@media(max-width:600px){.actions>.spark-toggle-top{grid-column:1/-1;justify-content:center;width:100%}}
+.overview{margin-bottom:13px}.overview .section-head{align-items:center;margin-bottom:12px}.overview .section-head h2{margin:0 0 3px}.overview-head-actions{display:flex;align-items:center;justify-content:flex-end;gap:8px;flex-wrap:wrap}.overview-head-actions button{padding:7px 10px;font-size:12px}.overview-toggle{display:inline-flex;align-items:center;gap:6px}.overview-toggle-icon{width:14px;height:14px;transition:transform .18s ease}.overview-toggle.collapsed .overview-toggle-icon{transform:rotate(180deg)}.overview-body[hidden]{display:none}.overview-table-wrap{overflow-x:auto;border:1px solid var(--line);border-radius:11px}.overview-table{width:1855px;min-width:100%;table-layout:fixed;border-collapse:collapse}.overview-table th,.overview-table td{text-align:left;padding:10px 12px;border-bottom:1px solid var(--line);white-space:nowrap}.overview-table th{color:var(--muted);font-size:11px;font-weight:550;background:color-mix(in srgb,var(--control) 70%,transparent)}.overview-heading-row th{position:relative;padding-right:18px}.overview-sort{display:inline-flex;align-items:center;gap:5px;max-width:100%;border:0;border-radius:5px;background:transparent;color:inherit;font:inherit;font-weight:650;padding:2px 0}.overview-sort span{overflow:hidden;text-overflow:ellipsis}.overview-sort:hover,.overview-sort:focus-visible{border:0;color:var(--blue);outline:0}.overview-sort-indicator{display:inline-block;min-width:12px;color:var(--muted);font-style:normal}.overview-sort.active .overview-sort-indicator{color:var(--blue)}.overview-column-resizer{position:absolute;z-index:2;top:0;right:-5px;width:11px;height:100%;cursor:col-resize;touch-action:none;user-select:none}.overview-column-resizer::after{content:"";position:absolute;top:20%;bottom:20%;left:5px;width:1px;background:var(--line);transition:background .12s,box-shadow .12s}.overview-column-resizer:hover::after,.overview-column-resizer:focus-visible::after,.overview-column-resizer.dragging::after{background:var(--blue);box-shadow:0 0 0 1px color-mix(in srgb,var(--blue) 28%,transparent)}.overview-column-resizer:focus-visible{outline:0}.overview-column-resizing,.overview-column-resizing *{cursor:col-resize!important;user-select:none!important}.overview-filter-row th{padding:7px 6px;background:color-mix(in srgb,var(--control) 48%,transparent)}.overview-filter{width:100%;min-width:88px;border-radius:7px;padding:6px 7px;font-size:11px}.overview-filter[data-overview-filter="account"]{min-width:230px}.overview-filter[data-overview-filter="capacity"],.overview-filter[data-overview-filter="forecast"]{min-width:150px}.overview-table td{font-size:12px;overflow:hidden;text-overflow:ellipsis}.overview-table tbody tr.sampled{cursor:pointer}.overview-table tbody tr.sampled:hover,.overview-table tbody tr.sampled:focus{outline:0;background:color-mix(in srgb,var(--blue) 8%,transparent)}.overview-table tbody tr.selected{background:color-mix(in srgb,var(--blue) 13%,transparent)}.overview-table tbody tr.unsampled{color:var(--muted)}.overview-table tr:last-child td{border-bottom:0}.overview-table .account-cell{overflow:hidden;text-overflow:ellipsis}.overview-table .capacity-cell span,.overview-table .capacity-cell small{display:block;overflow:hidden;text-overflow:ellipsis}.overview-table .capacity-cell small{color:var(--muted)}.overview-table .empty-cell{text-align:center;color:var(--muted);cursor:default;padding:24px}.overview-table .status-fast{color:var(--amber)}.overview-table .status-ok{color:var(--green)}.overview-table .status-exhausted{color:var(--red);font-weight:650}.overview-table .status-waiting{color:var(--muted)}.bad{color:var(--red)}@media(max-width:600px){.overview{margin-bottom:8px}.overview .section-head{align-items:stretch}.overview-head-actions{justify-content:flex-start}.overview-head-actions #overviewCount{flex-basis:100%}.overview-table th,.overview-table td{padding:9px 10px}}
+.overview .overview-toggle-icon{width:14px;height:14px;flex:0 0 14px}
+.overview .overview-filter{min-width:0}
 </style>
 </head>
 <body><main class="wrap">
 <div class="top"><h1>额度容量预测<span>把额度百分比变化映射为 Token 与美元等效容量</span></h1><div class="actions"><select id="account" aria-label="凭证账号"></select><select id="period" aria-label="预测周期"><option value="">当前预测</option></select><select id="language" aria-label="界面语言"></select><label class="spark-toggle spark-toggle-top"><input id="showSpark" type="checkbox"><span>显示 Spark 额度</span></label><button id="sync">同步价格</button><button id="refresh" class="primary">刷新</button></div></div>
+<section class="chart overview"><div class="section-head"><div><h2>全部账号额度概览</h2><div class="sub">合并 CPA 中已配置的 Codex OAuth 与插件采样；点击列名排序，逐列筛选；点击有样本的账号可查看详细预测</div></div><div class="overview-head-actions"><span class="sub" id="overviewCount">—</span><button id="overviewClearFilters" type="button">清除筛选</button><button id="overviewToggle" type="button" aria-expanded="true" aria-controls="overviewBody">折叠概览</button></div></div><div class="overview-body" id="overviewBody"><div class="overview-table-wrap"><table class="overview-table"><thead><tr class="overview-heading-row"><th><button class="overview-sort" type="button" data-sort-key="account"><span>账号</span><i class="overview-sort-indicator" aria-hidden="true">↕</i></button></th><th><button class="overview-sort" type="button" data-sort-key="plan"><span>计划类型</span><i class="overview-sort-indicator" aria-hidden="true">↕</i></button></th><th><button class="overview-sort" type="button" data-sort-key="remaining"><span>当前剩余额度</span><i class="overview-sort-indicator" aria-hidden="true">↕</i></button></th><th><button class="overview-sort" type="button" data-sort-key="reset"><span>重置时间</span><i class="overview-sort-indicator" aria-hidden="true">↕</i></button></th><th><button class="overview-sort" type="button" data-sort-key="requests"><span>请求数</span><i class="overview-sort-indicator" aria-hidden="true">↕</i></button></th><th><button class="overview-sort" type="button" data-sort-key="tokens"><span>Token</span><i class="overview-sort-indicator" aria-hidden="true">↕</i></button></th><th><button class="overview-sort" type="button" data-sort-key="cost"><span>等价费用</span><i class="overview-sort-indicator" aria-hidden="true">↕</i></button></th><th><button class="overview-sort" type="button" data-sort-key="capacity"><span>完整周期容量估计</span><i class="overview-sort-indicator" aria-hidden="true">↕</i></button></th><th><button class="overview-sort" type="button" data-sort-key="confidence"><span>估计置信度</span><i class="overview-sort-indicator" aria-hidden="true">↕</i></button></th><th><button class="overview-sort" type="button" data-sort-key="forecast"><span>预计耗尽 / 状态</span><i class="overview-sort-indicator" aria-hidden="true">↕</i></button></th></tr><tr class="overview-filter-row"><th><input class="overview-filter" data-overview-filter="account"></th><th><input class="overview-filter" data-overview-filter="plan"></th><th><input class="overview-filter" data-overview-filter="remaining"></th><th><input class="overview-filter" data-overview-filter="reset"></th><th><input class="overview-filter" data-overview-filter="requests"></th><th><input class="overview-filter" data-overview-filter="tokens"></th><th><input class="overview-filter" data-overview-filter="cost"></th><th><input class="overview-filter" data-overview-filter="capacity"></th><th><input class="overview-filter" data-overview-filter="confidence"></th><th><input class="overview-filter" data-overview-filter="forecast"></th></tr></thead><tbody id="overviewRows"></tbody></table></div></div></section>
 <section class="grid">
- <div class="card"><div class="label">所选周期额度使用率</div><div class="value" id="used">—</div><div class="sub" id="window">等待额度样本</div></div>
+ <div class="card"><div class="label">所选周期剩余额度</div><div class="value" id="used">—</div><div class="sub" id="window">等待额度样本</div></div>
  <div class="card"><div class="label">所选周期累计 Token</div><div class="value" id="tokens">—</div><div class="sub" id="requests">—</div></div>
  <div class="card"><div class="label">所选周期累计估算费用</div><div class="value" id="cost">—</div><div class="sub" id="pricing">—</div></div>
  <div class="card"><div class="label">预计额度耗尽</div><div class="value" id="exhaust">—</div><div class="sub" id="confidence">尚无预测</div></div>
@@ -45,6 +49,21 @@ const cpampAuthStorageKey = 'cli-proxy-auth';
 const sessionKeyStorageKey = 'cqe-key';
 const persistentKeyStorageKey = 'cqe-persistent-key';
 const showSparkStorageKey = 'cqe-show-spark-quota';
+const overviewPreferencesStorageKey = 'cqe-overview-preferences-v1';
+const overviewColumnMinimumWidth = 40;
+const overviewColumnMaximumWidth = 2000;
+const overviewColumns = [
+  {key: 'account', type: 'text', width: 330, minWidth: overviewColumnMinimumWidth},
+  {key: 'plan', type: 'text', width: 140, minWidth: overviewColumnMinimumWidth},
+  {key: 'remaining', type: 'number', width: 160, minWidth: overviewColumnMinimumWidth},
+  {key: 'reset', type: 'time', width: 160, minWidth: overviewColumnMinimumWidth},
+  {key: 'requests', type: 'number', width: 130, minWidth: overviewColumnMinimumWidth},
+  {key: 'tokens', type: 'number', width: 145, minWidth: overviewColumnMinimumWidth},
+  {key: 'cost', type: 'number', width: 140, minWidth: overviewColumnMinimumWidth},
+  {key: 'capacity', type: 'number', width: 220, minWidth: overviewColumnMinimumWidth},
+  {key: 'confidence', type: 'status', width: 150, minWidth: overviewColumnMinimumWidth},
+  {key: 'forecast', type: 'status', width: 280, minWidth: overviewColumnMinimumWidth}
+];
 const storedAuth = readStoredAuth();
 let key = storedAuth.key;
 let rememberKey = storedAuth.persistent;
@@ -54,6 +73,8 @@ let chartRange;
 let chartRangeCycleID;
 let chartRangeManual = false;
 let showSparkQuota = readShowSparkQuota();
+let overviewState = readOverviewState();
+let overviewSnapshot;
 let bridgeState = embedded ? 'unknown' : 'unavailable';
 let languageMode = readLanguageMode();
 let language = resolveLanguage();
@@ -64,6 +85,32 @@ function readShowSparkQuota() {
   } catch (_) {
     return false;
   }
+}
+
+function readOverviewState() {
+  let fallback = {collapsed: false, sortKey: '', sortDirection: 'asc', filters: {}, widths: {}};
+  try {
+    let stored = JSON.parse(localStorage.getItem(overviewPreferencesStorageKey) || '{}');
+    let validKeys = new Set(overviewColumns.map(column => column.key));
+    return {
+      collapsed: Boolean(stored.collapsed),
+      sortKey: validKeys.has(stored.sortKey) ? stored.sortKey : '',
+      sortDirection: stored.sortDirection === 'desc' ? 'desc' : 'asc',
+      filters: Object.fromEntries(Object.entries(stored.filters || {})
+        .filter(entry => validKeys.has(entry[0]) && typeof entry[1] === 'string')),
+      widths: Object.fromEntries(Object.entries(stored.widths || {})
+        .filter(entry => validKeys.has(entry[0]) && Number.isFinite(+entry[1]))
+        .map(entry => [entry[0], +entry[1]]))
+    };
+  } catch (_) {
+    return fallback;
+  }
+}
+
+function storeOverviewState() {
+  try {
+    localStorage.setItem(overviewPreferencesStorageKey, JSON.stringify(overviewState));
+  } catch (_) {}
 }
 
 function readStoredAuth() {
@@ -244,7 +291,34 @@ const messages = {
     noCycleRecords: '所选月份暂无额度周期记录',
     capacityRange: '{low} — {high}',
     monthlyMethodNote: '仅统计主额度请求；实际 Token 按请求发生时间归属月份，Spark 在下方独立汇总。',
-    sparkMonthlyMethodNote: '仅统计 Spark 请求；容量、额度消耗当量和周期均与主额度分开。'
+    sparkMonthlyMethodNote: '仅统计 Spark 请求；容量、额度消耗当量和周期均与主额度分开。',
+    overviewAccountCount: '已采样 {count} 个账号',
+    overviewDescription: '合并 CPA 中已配置的 Codex OAuth 与插件采样；点击列名排序，逐列筛选；拖动列边界调整宽度',
+    overviewConfiguredCount: '已配置 {configured} 个 Codex OAuth · 已采样 {sampled} 个 · 待采样 {waiting} 个 · 当前显示 {visible} 个',
+    overviewAuthUnavailable: '已采样 {sampled} 个账号 · OAuth 清单暂不可读 · 当前显示 {visible} 个',
+    overviewEmpty: '暂无账号额度样本',
+    overviewNoMatches: '没有账号符合当前筛选条件',
+    overviewLoadFailed: '概览加载失败：{message}',
+    overviewForecastExhaust: '{time} · 预计提前耗尽',
+    overviewForecastReset: '可用至 {time} · {status}',
+    overviewExhausted: '额度已耗尽 · {time} 重置',
+    overviewExhaustedStale: '末次样本额度已耗尽 · 等待重置后新样本',
+    overviewAwaitingRefresh: '已到重置时间 · 等待新样本',
+    overviewAwaitingFirstSample: '等待首次经 CPA 调用',
+    overviewCapacityTokens: 'Token：{value}',
+    overviewCapacityCost: 'USD：{value}',
+    overviewFilterPlaceholder: '筛选…',
+    overviewFilterLabel: '筛选“{column}”；数值和时间支持 >、>=、<、<=、=',
+    overviewSortLabel: '按“{column}”排序',
+    overviewSortAscending: '升序',
+    overviewSortDescending: '降序',
+    overviewExpand: '展开概览',
+    overviewCollapse: '折叠概览',
+    overviewClearFilters: '清除筛选',
+    overviewResizeLabel: '调整“{column}”列宽',
+    overviewResizeHint: '拖动调整列宽；双击恢复默认宽度',
+    quotaExhausted: '额度已耗尽',
+    quotaAwaitingRefresh: '等待重置后新样本'
   },
   en: {
     autoLanguage: 'Auto (follow panel)',
@@ -349,7 +423,34 @@ const messages = {
     noCycleRecords: 'No quota cycles in the selected month',
     capacityRange: '{low} — {high}',
     monthlyMethodNote: 'Only primary-quota requests are counted here. Spark is summarized separately below.',
-    sparkMonthlyMethodNote: 'Only Spark requests are counted here. Capacity, quota equivalents, and cycles remain separate from the primary quota.'
+    sparkMonthlyMethodNote: 'Only Spark requests are counted here. Capacity, quota equivalents, and cycles remain separate from the primary quota.',
+    overviewAccountCount: '{count} sampled accounts',
+    overviewDescription: 'Merge configured Codex OAuth with plugin samples; select a heading to sort, filter each field, or drag a column edge to resize',
+    overviewConfiguredCount: '{configured} Codex OAuth configured · {sampled} sampled · {waiting} awaiting samples · {visible} shown',
+    overviewAuthUnavailable: '{sampled} sampled accounts · OAuth inventory unavailable · {visible} shown',
+    overviewEmpty: 'No account quota samples yet',
+    overviewNoMatches: 'No accounts match the current filters',
+    overviewLoadFailed: 'Failed to load overview: {message}',
+    overviewForecastExhaust: '{time} · expected to exhaust early',
+    overviewForecastReset: 'Usable until {time} · {status}',
+    overviewExhausted: 'Quota exhausted · resets {time}',
+    overviewExhaustedStale: 'Last sample was exhausted · awaiting a post-reset sample',
+    overviewAwaitingRefresh: 'Reset time reached · awaiting a new sample',
+    overviewAwaitingFirstSample: 'Awaiting first request through CPA',
+    overviewCapacityTokens: 'Tokens: {value}',
+    overviewCapacityCost: 'USD: {value}',
+    overviewFilterPlaceholder: 'Filter…',
+    overviewFilterLabel: 'Filter “{column}”; number and time fields support >, >=, <, <=, =',
+    overviewSortLabel: 'Sort by “{column}”',
+    overviewSortAscending: 'ascending',
+    overviewSortDescending: 'descending',
+    overviewExpand: 'Expand overview',
+    overviewCollapse: 'Collapse overview',
+    overviewClearFilters: 'Clear filters',
+    overviewResizeLabel: 'Resize the “{column}” column',
+    overviewResizeHint: 'Drag to resize; double-click to restore the default width',
+    quotaExhausted: 'Quota exhausted',
+    quotaAwaitingRefresh: 'Awaiting a post-reset sample'
   }
 };
 
@@ -358,6 +459,19 @@ const staticEnglish = {
   '把额度百分比变化映射为 Token 与美元等效容量': 'Map quota percentage changes to Token and USD-equivalent capacity',
   '同步价格': 'Sync pricing',
   '刷新': 'Refresh',
+  '全部账号额度概览': 'All-account quota overview',
+  '合并 CPA 中已配置的 Codex OAuth 与插件采样；点击列名排序，逐列筛选；点击有样本的账号可查看详细预测': 'Merge configured Codex OAuth credentials with plugin samples; select a column to sort, filter each field, or open a sampled account for details',
+  '清除筛选': 'Clear filters',
+  '折叠概览': 'Collapse overview',
+  '账号': 'Account',
+  '计划类型': 'Plan type',
+  '重置时间': 'Reset time',
+  '请求数': 'Requests',
+  'Token': 'Tokens',
+  '等价费用': 'Equivalent cost',
+  '完整周期容量估计': 'Full-cycle capacity estimate',
+  '预计耗尽 / 状态': 'Estimated exhaustion / status',
+  '当前剩余额度': 'Current quota remaining',
   '曲线范围': 'Chart range',
   '至': 'to',
   '恢复本周期': 'Reset to cycle',
@@ -365,7 +479,7 @@ const staticEnglish = {
   '当前周期': 'Current cycle',
   '当前预测': 'Current forecast',
   '预测周期': 'Forecast cycle',
-  '所选周期额度使用率': 'Selected-cycle quota used',
+  '所选周期剩余额度': 'Selected-cycle quota remaining',
   '等待额度样本': 'Waiting for quota samples',
   '所选周期累计 Token': 'Selected-cycle cumulative Tokens',
   '所选周期累计估算费用': 'Selected-cycle cumulative estimated cost',
@@ -567,6 +681,7 @@ function applyLanguage(nextLanguage) {
   $('#rangeEnd').setAttribute('aria-label', tr('rangeEndLabel'));
   $('#showSpark').setAttribute('aria-label', language === 'en' ? 'Show Spark quota' : '显示 Spark 额度');
   renderLanguageSelect();
+  renderOverviewControls();
 }
 
 function setLanguageMode(mode) {
@@ -771,7 +886,7 @@ window.addEventListener('message', event => {
   }
 });
 
-function bridgeApi(path, options) {
+function bridgeRequest(path, options) {
   options = options || {};
   return new Promise((resolve, reject) => {
     let id = crypto.randomUUID ? crypto.randomUUID() : Date.now() + '-' + Math.random();
@@ -784,11 +899,15 @@ function bridgeApi(path, options) {
     window.parent.postMessage({
       type: 'cpamp:plugin-api-request',
       id: id,
-      path: base + path,
+      path: path,
       method: options.method || 'GET',
       body: options.body
     }, window.location.origin);
   });
+}
+
+function bridgeApi(path, options) {
+  return bridgeRequest(base + path, options);
 }
 
 async function directApi(path, options) {
@@ -819,6 +938,64 @@ async function api(path, options) {
   return directApi(path, options);
 }
 
+async function directManagementApi(path, options) {
+  options = options || {};
+  let headers = Object.assign({}, options.headers || {});
+  if (options.body && !headers['Content-Type']) headers['Content-Type'] = 'application/json';
+  if (key) headers.Authorization = 'Bearer ' + key;
+  let response = await fetch('/v0/management' + path, Object.assign({}, options, {headers: headers}));
+  if (response.status === 401 || response.status === 403) {
+    throw Object.assign(new Error(tr('managementKeyRequired')), {auth: true});
+  }
+  if (!response.ok) throw new Error(await response.text());
+  return response.json();
+}
+
+async function managementApi(path, options) {
+  let directError;
+  if (key) {
+    try {
+      return await directManagementApi(path, options);
+    } catch (error) {
+      directError = error;
+    }
+  }
+  if (embedded && bridgeState !== 'unavailable') {
+    try {
+      return await bridgeRequest('/v0/management' + path, options);
+    } catch (error) {
+      if (!directError) directError = error;
+    }
+  }
+  throw directError || new Error(tr('bridgeUnavailable'));
+}
+
+function credentialPlan(file) {
+  let explicit = String(file.account_type || file.plan_type || '').trim().toLowerCase();
+  let knownPlans = ['free', 'k12', 'team', 'plus', 'pro', 'business', 'enterprise', 'edu'];
+  if (knownPlans.includes(explicit)) return explicit;
+  let name = String(file.name || file.id || '');
+  let match = name.match(/-(free|k12|team|plus|pro|business|enterprise|edu)(?:\.json)?$/i);
+  return match ? match[1].toLowerCase() : '';
+}
+
+async function loadConfiguredCodexAccounts() {
+  let response = await managementApi('/auth-files');
+  let byName = new Map();
+  (response.files || []).forEach(file => {
+    let provider = String(file.provider || file.type || '').trim().toLowerCase();
+    let name = String(file.name || file.id || '').trim();
+    if (provider !== 'codex' || !name || byName.has(name)) return;
+    byName.set(name, {
+      account: name,
+      plan_type: credentialPlan(file),
+      disabled: Boolean(file.disabled),
+      unavailable: Boolean(file.unavailable)
+    });
+  });
+  return Array.from(byName.values()).sort((a, b) => a.account.localeCompare(b.account));
+}
+
 function showLogin(message) {
   $('#login').classList.add('show');
   $('#loginError').textContent = message || '';
@@ -837,9 +1014,28 @@ async function load() {
     let period = $('#period').value;
     if (account) query.set('account', account);
     if (period) query.set('cycle_id', period);
-    let summary = await api('/summary' + (query.size ? '?' + query : ''));
+    let initial = await Promise.allSettled([
+      api('/overview'),
+      api('/summary' + (query.size ? '?' + query : '')),
+      loadConfiguredCodexAccounts()
+    ]);
+    if (initial[1].status === 'rejected') throw initial[1].reason;
+    let summary = initial[1].value;
     state = summary;
     $('#login').classList.remove('show');
+    let configuredAccounts = initial[2].status === 'fulfilled'
+      ? {available: true, accounts: initial[2].value}
+      : {available: false, accounts: []};
+    if (initial[0].status === 'fulfilled') {
+      renderOverview(initial[0].value, summary.account, configuredAccounts);
+    } else if (initial[0].reason && initial[0].reason.auth) {
+      throw initial[0].reason;
+    } else {
+      renderOverview({accounts: []}, summary.account, configuredAccounts);
+      $('#overviewCount').textContent = tr('overviewLoadFailed', {
+        message: initial[0].reason && initial[0].reason.message || tr('requestFailed')
+      });
+    }
     renderSummary(summary);
     let seriesQuery = new URLSearchParams({limit: '5000'});
     if (summary.account) seriesQuery.set('account', summary.account);
@@ -876,6 +1072,406 @@ async function load() {
       $('#note').textContent = tr('loadFailed', {message: error.message});
     }
   }
+}
+
+function appendOverviewCell(row, value, className) {
+  let cell = document.createElement('td');
+  if (className) cell.className = className;
+  cell.textContent = value;
+  if (value && value !== '—') cell.title = value;
+  row.append(cell);
+  return cell;
+}
+
+function overviewForecast(item) {
+  let point = item.latest;
+  let burn = item.burn_forecast || {};
+  if (!point) return {text: tr('overviewAwaitingFirstSample'), className: 'status-waiting'};
+  let now = Date.now() / 1000;
+  if (item.quota_status === 'exhausted' || Number(point.used_percent || 0) >= 99.5) {
+    return point.reset_at && point.reset_at <= now
+      ? {text: tr('overviewExhaustedStale'), className: 'status-exhausted'}
+      : {text: tr('overviewExhausted', {time: dt(point.reset_at)}), className: 'status-exhausted'};
+  }
+  if (item.quota_status === 'awaiting_refresh' || point.reset_at && point.reset_at <= now) {
+    return {text: tr('overviewAwaitingRefresh'), className: 'status-waiting'};
+  }
+  let status = burn.status === 'fast' ? tr('paceFast')
+    : burn.status === 'slow' ? tr('paceSlow')
+    : burn.status === 'on_track' ? tr('paceOnTrack')
+    : tr('paceWaiting');
+  let useRecent = burn.recent_available;
+  let willExhaust = useRecent ? burn.recent_will_exhaust_before_reset : burn.will_exhaust_before_reset;
+  let exhaustAt = useRecent ? burn.recent_estimated_exhaust_at : burn.estimated_exhaust_at;
+  if (burn.available && willExhaust && exhaustAt) {
+    return {text: tr('overviewForecastExhaust', {time: dt(exhaustAt)}), className: 'status-fast'};
+  }
+  return {
+    text: tr('overviewForecastReset', {time: dt(point.reset_at), status: status}),
+    className: burn.status === 'fast' ? 'status-fast' : 'status-ok'
+  };
+}
+
+function mergeOverviewAccounts(data, configured) {
+  let sampled = (data && data.accounts || []).map(item => Object.assign({}, item, {sampled: true}));
+  if (!configured || !configured.available) return sampled;
+  let byAccount = new Map(sampled.map(item => [item.account, item]));
+  configured.accounts.forEach(file => {
+    let existing = byAccount.get(file.account);
+    if (existing) {
+      existing.configured = true;
+      if (!existing.plan_type && file.plan_type) existing.plan_type = file.plan_type;
+      return;
+    }
+    let item = Object.assign({sampled: false, configured: true}, file);
+    byAccount.set(item.account, item);
+  });
+  return Array.from(byAccount.values()).sort((a, b) => String(a.account).localeCompare(String(b.account)));
+}
+
+function overviewColumnWidth(column) {
+  let stored = Number(overviewState.widths[column.key]);
+  let width = Number.isFinite(stored) ? stored : column.width;
+  return Math.min(overviewColumnMaximumWidth, Math.max(column.minWidth, Math.round(width)));
+}
+
+function applyOverviewColumnWidths() {
+  let table = document.querySelector('.overview-table');
+  if (!table) return;
+  let total = 0;
+  overviewColumns.forEach(column => {
+    let width = overviewColumnWidth(column);
+    total += width;
+    let col = table.querySelector('[data-overview-column="' + column.key + '"]');
+    if (col) col.style.width = width + 'px';
+    let handle = document.querySelector('[data-overview-resizer="' + column.key + '"]');
+    if (handle) {
+      handle.setAttribute('aria-valuemin', String(column.minWidth));
+      handle.setAttribute('aria-valuemax', String(overviewColumnMaximumWidth));
+      handle.setAttribute('aria-valuenow', String(width));
+    }
+  });
+  table.style.width = total + 'px';
+}
+
+function setupOverviewColumnResizers() {
+  let table = document.querySelector('.overview-table');
+  let headings = document.querySelectorAll('.overview-heading-row th');
+  if (!table || headings.length !== overviewColumns.length) return;
+  let colgroup = table.querySelector('colgroup');
+  if (!colgroup) {
+    colgroup = document.createElement('colgroup');
+    overviewColumns.forEach(column => {
+      let col = document.createElement('col');
+      col.dataset.overviewColumn = column.key;
+      colgroup.append(col);
+    });
+    table.insertBefore(colgroup, table.firstChild);
+  }
+  let toggle = $('#overviewToggle');
+  toggle.classList.add('overview-toggle');
+  if (!$('#overviewToggleLabel')) {
+    let label = toggle.textContent.trim() || '折叠概览';
+    toggle.innerHTML = '<svg class="overview-toggle-icon" viewBox="0 0 20 20" fill="none" aria-hidden="true"><path d="M4.5 12.5 10 7l5.5 5.5" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/></svg><span id="overviewToggleLabel"></span>';
+    $('#overviewToggleLabel').textContent = label;
+  }
+  overviewColumns.forEach((column, index) => {
+    let heading = headings[index];
+    let handle = heading.querySelector('.overview-column-resizer');
+    if (!handle) {
+      handle = document.createElement('span');
+      handle.className = 'overview-column-resizer';
+      handle.dataset.overviewResizer = column.key;
+      handle.tabIndex = 0;
+      handle.setAttribute('role', 'separator');
+      handle.setAttribute('aria-orientation', 'vertical');
+      heading.append(handle);
+    }
+    let drag = null;
+    let finishDrag = event => {
+      if (!drag || event.pointerId !== drag.pointerId) return;
+      if (handle.hasPointerCapture(event.pointerId)) handle.releasePointerCapture(event.pointerId);
+      handle.classList.remove('dragging');
+      document.body.classList.remove('overview-column-resizing');
+      drag = null;
+      storeOverviewState();
+    };
+    handle.onpointerdown = event => {
+      if (event.button !== 0) return;
+      event.preventDefault();
+      event.stopPropagation();
+      drag = {pointerId: event.pointerId, startX: event.clientX, startWidth: overviewColumnWidth(column)};
+      handle.setPointerCapture(event.pointerId);
+      handle.classList.add('dragging');
+      document.body.classList.add('overview-column-resizing');
+    };
+    handle.onpointermove = event => {
+      if (!drag || event.pointerId !== drag.pointerId) return;
+      overviewState.widths[column.key] = Math.min(overviewColumnMaximumWidth,
+        Math.max(column.minWidth, drag.startWidth + event.clientX - drag.startX));
+      applyOverviewColumnWidths();
+    };
+    handle.onpointerup = finishDrag;
+    handle.onpointercancel = finishDrag;
+    handle.ondblclick = event => {
+      event.preventDefault();
+      event.stopPropagation();
+      delete overviewState.widths[column.key];
+      storeOverviewState();
+      applyOverviewColumnWidths();
+    };
+    handle.onkeydown = event => {
+      if (!['ArrowLeft', 'ArrowRight', 'Home'].includes(event.key)) return;
+      event.preventDefault();
+      event.stopPropagation();
+      if (event.key === 'Home') delete overviewState.widths[column.key];
+      else {
+        let step = event.shiftKey ? 40 : 10;
+        let direction = event.key === 'ArrowRight' ? 1 : -1;
+        overviewState.widths[column.key] = overviewColumnWidth(column) + direction * step;
+      }
+      storeOverviewState();
+      applyOverviewColumnWidths();
+    };
+  });
+  applyOverviewColumnWidths();
+}
+
+function renderOverviewControls() {
+  let body = $('#overviewBody');
+  if (!body) return;
+  let description = document.querySelector('.overview .section-head > div > .sub');
+  if (description) description.textContent = tr('overviewDescription');
+  body.hidden = overviewState.collapsed;
+  let toggle = $('#overviewToggle');
+  let toggleLabel = $('#overviewToggleLabel');
+  if (toggleLabel) toggleLabel.textContent = tr(overviewState.collapsed ? 'overviewExpand' : 'overviewCollapse');
+  else toggle.textContent = tr(overviewState.collapsed ? 'overviewExpand' : 'overviewCollapse');
+  toggle.classList.toggle('collapsed', overviewState.collapsed);
+  toggle.setAttribute('aria-expanded', overviewState.collapsed ? 'false' : 'true');
+  let hasFilters = Object.values(overviewState.filters).some(value => String(value).trim());
+  let clear = $('#overviewClearFilters');
+  clear.textContent = tr('overviewClearFilters');
+  clear.disabled = !hasFilters;
+  document.querySelectorAll('[data-overview-filter]').forEach(input => {
+    let key = input.dataset.overviewFilter;
+    let sortButton = document.querySelector('[data-sort-key="' + key + '"]');
+    let columnLabel = sortButton && sortButton.querySelector('span').textContent || key;
+    let filterValue = overviewState.filters[key] || '';
+    if (input.value !== filterValue) input.value = filterValue;
+    input.placeholder = tr('overviewFilterPlaceholder');
+    input.setAttribute('aria-label', tr('overviewFilterLabel', {column: columnLabel}));
+    input.title = tr('overviewFilterLabel', {column: columnLabel});
+  });
+  document.querySelectorAll('[data-sort-key]').forEach(button => {
+    let key = button.dataset.sortKey;
+    let active = overviewState.sortKey === key;
+    let label = button.querySelector('span').textContent;
+    let indicator = button.querySelector('.overview-sort-indicator');
+    button.classList.toggle('active', active);
+    indicator.textContent = active ? (overviewState.sortDirection === 'desc' ? '↓' : '↑') : '↕';
+    button.setAttribute('aria-label', tr('overviewSortLabel', {column: label}) +
+      (active ? ' · ' + tr(overviewState.sortDirection === 'desc' ? 'overviewSortDescending' : 'overviewSortAscending') : ''));
+    button.title = button.getAttribute('aria-label');
+    let heading = button.closest('th');
+    if (active) heading.setAttribute('aria-sort', overviewState.sortDirection === 'desc' ? 'descending' : 'ascending');
+    else heading.removeAttribute('aria-sort');
+  });
+  overviewColumns.forEach(column => {
+    let handle = document.querySelector('[data-overview-resizer="' + column.key + '"]');
+    let button = document.querySelector('[data-sort-key="' + column.key + '"]');
+    if (!handle || !button) return;
+    let columnLabel = button.querySelector('span').textContent;
+    handle.setAttribute('aria-label', tr('overviewResizeLabel', {column: columnLabel}));
+    handle.title = tr('overviewResizeHint');
+  });
+  applyOverviewColumnWidths();
+}
+
+function overviewRowData(item) {
+  let point = item.latest;
+  let estimate = item.estimate || {};
+  let remaining = point
+    ? Number.isFinite(+item.remaining_percent)
+      ? +item.remaining_percent
+      : Math.max(0, 100 - Number(point.used_percent || 0))
+    : NaN;
+  let forecast = overviewForecast(item);
+  let confidence = estimate.available ? confidenceLabel(estimate.confidence) : tr('insufficientSamples');
+  let capacityTokens = tr('overviewCapacityTokens', {
+    value: estimate.available ? fmt(estimate.full_window_tokens) : '—'
+  });
+  let capacityCost = tr('overviewCapacityCost', {
+    value: estimate.available ? usd(estimate.full_window_cost_usd) : '—'
+  }) + (estimate.available ? '' : ' · ' + tr('insufficientSamples'));
+  let text = {
+    account: item.account || '—',
+    plan: item.plan_type || '—',
+    remaining: Number.isFinite(remaining) ? remaining.toFixed(0) + '%' : '—',
+    reset: point ? dt(point.reset_at) : '—',
+    requests: point ? fmt(point.requests) : '—',
+    tokens: point ? fmt(point.window_tokens) : '—',
+    cost: point ? usd(point.window_cost_usd) : '—',
+    capacity: capacityTokens + ' ' + capacityCost,
+    confidence: confidence,
+    forecast: forecast.text
+  };
+  let confidenceRank = {insufficient: 0, low: 1, medium: 2, high: 3}[estimate.confidence] || 0;
+  let forecastRank = forecast.className === 'status-exhausted' ? 3
+    : forecast.className === 'status-fast' ? 2
+    : forecast.className === 'status-ok' ? 1 : 0;
+  return {
+    item: item,
+    point: point,
+    estimate: estimate,
+    remaining: remaining,
+    forecast: forecast,
+    capacityTokens: capacityTokens,
+    capacityCost: capacityCost,
+    text: text,
+    sort: {
+      account: String(item.account || ''),
+      plan: String(item.plan_type || ''),
+      remaining: remaining,
+      reset: point ? Number(point.reset_at) : NaN,
+      requests: point ? Number(point.requests) : NaN,
+      tokens: point ? Number(point.window_tokens) : NaN,
+      cost: point ? Number(point.window_cost_usd) : NaN,
+      capacity: estimate.available ? Number(estimate.full_window_tokens) : NaN,
+      confidence: confidenceRank,
+      forecast: forecastRank
+    }
+  };
+}
+
+function compareOverviewFilter(rawValue, expression, type) {
+  let match = expression.match(/^\s*(>=|<=|>|<|=)\s*(.+?)\s*$/);
+  if (!match || !['number', 'time'].includes(type)) return null;
+  let expected = type === 'time' ? Date.parse(match[2]) / 1000 : Number(match[2].replaceAll(',', ''));
+  let actual = Number(rawValue);
+  if (!Number.isFinite(actual) || !Number.isFinite(expected)) return false;
+  if (match[1] === '>=') return actual >= expected;
+  if (match[1] === '<=') return actual <= expected;
+  if (match[1] === '>') return actual > expected;
+  if (match[1] === '<') return actual < expected;
+  return actual === expected;
+}
+
+function matchesOverviewFilters(rowData) {
+  return overviewColumns.every(column => {
+    let expression = String(overviewState.filters[column.key] || '').trim();
+    if (!expression) return true;
+    let comparison = compareOverviewFilter(rowData.sort[column.key], expression, column.type);
+    if (comparison !== null) return comparison;
+    return String(rowData.text[column.key] || '').toLocaleLowerCase().includes(expression.toLocaleLowerCase());
+  });
+}
+
+function compareOverviewRows(left, right) {
+  let column = overviewColumns.find(item => item.key === overviewState.sortKey);
+  if (!column) return String(left.item.account || '').localeCompare(String(right.item.account || ''));
+  let a = left.sort[column.key];
+  let b = right.sort[column.key];
+  let aMissing = a === null || a === undefined || (typeof a === 'number' && !Number.isFinite(a)) || a === '';
+  let bMissing = b === null || b === undefined || (typeof b === 'number' && !Number.isFinite(b)) || b === '';
+  if (aMissing !== bMissing) return aMissing ? 1 : -1;
+  let comparison = 0;
+  if (!aMissing) {
+    comparison = column.type === 'text'
+      ? String(a).localeCompare(String(b), language, {numeric: true, sensitivity: 'base'})
+      : Number(a) - Number(b);
+  }
+  if (comparison) return overviewState.sortDirection === 'desc' ? -comparison : comparison;
+  return String(left.item.account || '').localeCompare(String(right.item.account || ''));
+}
+
+function renderOverviewFromSnapshot() {
+  if (!overviewSnapshot) {
+    renderOverviewControls();
+    return;
+  }
+  renderOverview(overviewSnapshot.data, overviewSnapshot.selectedAccount, overviewSnapshot.configured);
+}
+
+function renderOverview(data, selectedAccount, configured) {
+  overviewSnapshot = {data: data, selectedAccount: selectedAccount, configured: configured};
+  let items = mergeOverviewAccounts(data, configured);
+  let rows = items.map(overviewRowData).filter(matchesOverviewFilters).sort(compareOverviewRows);
+  let body = $('#overviewRows');
+  body.replaceChildren();
+  let sampledCount = items.filter(item => item.sampled).length;
+  let waitingCount = items.filter(item => item.configured && !item.sampled).length;
+  $('#overviewCount').textContent = configured && configured.available
+    ? tr('overviewConfiguredCount', {
+      configured: configured.accounts.length,
+      sampled: sampledCount,
+      waiting: waitingCount,
+      visible: rows.length
+    })
+    : tr('overviewAuthUnavailable', {sampled: sampledCount, visible: rows.length});
+  renderOverviewControls();
+  if (!items.length) {
+    let row = document.createElement('tr');
+    let cell = appendOverviewCell(row, tr('overviewEmpty'), 'empty-cell');
+    cell.colSpan = 10;
+    body.append(row);
+    return;
+  }
+  if (!rows.length) {
+    let row = document.createElement('tr');
+    let cell = appendOverviewCell(row, tr('overviewNoMatches'), 'empty-cell');
+    cell.colSpan = 10;
+    body.append(row);
+    return;
+  }
+  rows.forEach(rowData => {
+    let item = rowData.item;
+    let row = document.createElement('tr');
+    row.classList.add(item.sampled ? 'sampled' : 'unsampled');
+    if (item.account === selectedAccount) row.classList.add('selected');
+    if (item.sampled) {
+      row.tabIndex = 0;
+      row.setAttribute('role', 'button');
+    }
+    let accountCell = appendOverviewCell(row, rowData.text.account, 'account-cell');
+    accountCell.title = item.account || '';
+    appendOverviewCell(row, rowData.text.plan);
+    appendOverviewCell(row, rowData.text.remaining);
+    appendOverviewCell(row, rowData.text.reset);
+    appendOverviewCell(row, rowData.text.requests);
+    appendOverviewCell(row, rowData.text.tokens);
+    appendOverviewCell(row, rowData.text.cost);
+    let capacityCell = document.createElement('td');
+    capacityCell.className = 'capacity-cell';
+    let capacityTokens = document.createElement('span');
+    capacityTokens.textContent = rowData.capacityTokens;
+    let capacityCost = document.createElement('small');
+    capacityCost.textContent = rowData.capacityCost;
+    capacityCell.append(capacityTokens, capacityCost);
+    capacityCell.title = rowData.text.capacity;
+    row.append(capacityCell);
+    appendOverviewCell(row, rowData.text.confidence);
+    appendOverviewCell(row, rowData.forecast.text, rowData.forecast.className);
+    let selectAccount = () => {
+      if (!item.sampled || !item.account || item.account === $('#account').value) return;
+      $('#account').value = item.account;
+      $('#period').value = '';
+      $('#month').value = '';
+      chartRangeManual = false;
+      chartRange = null;
+      load();
+    };
+    if (item.sampled) {
+      row.onclick = selectAccount;
+      row.onkeydown = event => {
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault();
+          selectAccount();
+        }
+      };
+    }
+    body.append(row);
+  });
 }
 
 function renderAccounts(summary) {
@@ -1030,8 +1626,16 @@ function renderSummary(summary) {
   let config = summary.config || {};
   let historical = summary.is_current === false;
 
-  $('#used').textContent = point ? point.used_percent.toFixed(0) + '%' : '—';
-  $('#used').className = 'value ' + (point && point.used_percent >= 80 ? 'warn' : 'good');
+  let remaining = point
+    ? Number.isFinite(+summary.remaining_percent)
+      ? +summary.remaining_percent
+      : Math.max(0, 100 - Number(point.used_percent || 0))
+    : NaN;
+  let quotaStatus = summary.quota_status || (point && Number(point.used_percent || 0) >= 99.5
+    ? 'exhausted'
+    : point && point.reset_at <= Date.now() / 1000 ? 'awaiting_refresh' : 'active');
+  $('#used').textContent = Number.isFinite(remaining) ? remaining.toFixed(0) + '%' : '—';
+  $('#used').className = 'value ' + (quotaStatus === 'exhausted' ? 'bad' : remaining <= 20 ? 'warn' : 'good');
   $('#window').textContent = point
     ? dt(summary.window_start) + ' — ' + dt(point.reset_at)
     : tr('waitingQuota');
@@ -1044,17 +1648,27 @@ function renderSummary(summary) {
 
   let forecastExhausts = burn.recent_available ? burn.recent_will_exhaust_before_reset : burn.will_exhaust_before_reset;
   let forecastEnd = burn.recent_available ? burn.recent_estimated_exhaust_at : burn.estimated_exhaust_at;
-  $('#exhaust').textContent = burn.available
-    ? (forecastExhausts ? dt(forecastEnd) : tr('usableUntilReset'))
-    : (estimate.estimated_exhaust_at ? dt(estimate.estimated_exhaust_at) : '—');
+  $('#exhaust').textContent = quotaStatus === 'exhausted'
+    ? tr('quotaExhausted')
+    : quotaStatus === 'awaiting_refresh'
+      ? tr('quotaAwaitingRefresh')
+      : burn.available
+        ? (forecastExhausts ? dt(forecastEnd) : tr('usableUntilReset'))
+        : (estimate.estimated_exhaust_at ? dt(estimate.estimated_exhaust_at) : '—');
 
-  let confidenceText = burn.available
-    ? (burn.recent_available
-      ? tr('recentRate', {rate: burn.recent_percent_per_day.toFixed(1)})
-      : tr('averageRate', {rate: burn.average_percent_per_day.toFixed(1)}))
-    : (estimate.available
-      ? tr('confidence', {level: confidenceLabel(estimate.confidence)})
-      : tr('insufficientGrowth'));
+  let confidenceText = quotaStatus === 'exhausted'
+    ? (point && point.reset_at <= Date.now() / 1000
+      ? tr('overviewExhaustedStale')
+      : tr('overviewExhausted', {time: dt(point && point.reset_at)}))
+    : quotaStatus === 'awaiting_refresh'
+      ? tr('overviewAwaitingRefresh')
+      : burn.available
+        ? (burn.recent_available
+          ? tr('recentRate', {rate: burn.recent_percent_per_day.toFixed(1)})
+          : tr('averageRate', {rate: burn.average_percent_per_day.toFixed(1)}))
+        : (estimate.available
+          ? tr('confidence', {level: confidenceLabel(estimate.confidence)})
+          : tr('insufficientGrowth'));
   $('#confidence').textContent = (historical ? tr('historyLastPrediction') : '') + confidenceText;
 
   $('#fullTokens').textContent = estimate.available ? fmt(estimate.full_window_tokens) : '—';
@@ -1122,12 +1736,15 @@ function renderPace(series, range) {
     return;
   }
 
-  let status = burn.status === 'fast' ? [tr('paceFast'), 'fast']
+  let exhausted = Number(burn.used_percent || 0) >= 99.5;
+  let status = exhausted ? [tr('quotaExhausted'), 'exhausted']
+    : burn.status === 'fast' ? [tr('paceFast'), 'fast']
     : burn.status === 'slow' ? [tr('paceSlow'), 'slow']
     : burn.status === 'on_track' ? [tr('paceOnTrack'), '']
     : [tr('paceWaiting'), ''];
   let delta = Math.abs(burn.pace_delta_percent || 0);
-  let comparison = burn.status === 'fast'
+  let comparison = exhausted ? tr('quotaExhausted')
+    : burn.status === 'fast'
     ? tr('fasterBy', {delta: delta.toFixed(1)})
     : burn.status === 'slow'
       ? tr('slowerBy', {delta: delta.toFixed(1)})
@@ -1153,12 +1770,13 @@ function renderPace(series, range) {
       duration: duration(burn.recent_window_seconds)
     })
     : tr('insufficientSamples');
-  $('#averageEnd').textContent = burn.will_exhaust_before_reset
-    ? dt(burn.estimated_exhaust_at) : tr('usableUntilThisReset');
+  $('#averageEnd').textContent = exhausted ? tr('quotaExhausted')
+    : burn.will_exhaust_before_reset ? dt(burn.estimated_exhaust_at) : tr('usableUntilThisReset');
 
   let recentWill = burn.recent_available ? burn.recent_will_exhaust_before_reset : burn.will_exhaust_before_reset;
   let recentEnd = burn.recent_available ? burn.recent_estimated_exhaust_at : burn.estimated_exhaust_at;
-  $('#paceEnd').textContent = recentWill ? dt(recentEnd) : tr('usableUntilThisReset');
+  $('#paceEnd').textContent = exhausted ? tr('quotaExhausted')
+    : recentWill ? dt(recentEnd) : tr('usableUntilThisReset');
   let projected = burn.recent_available ? burn.recent_projected_at_reset : burn.projected_used_at_reset || 0;
   $('#projectedUsage').textContent = recentWill
     ? tr('projectedExhaust', {percent: projected.toFixed(0)})
@@ -1463,6 +2081,39 @@ function renderSparkQuota(seriesData) {
     '" preserveAspectRatio="xMidYMid meet">' + svg + '</svg>';
 }
 
+document.querySelectorAll('[data-sort-key]').forEach(button => {
+  button.onclick = () => {
+    let key = button.dataset.sortKey;
+    if (overviewState.sortKey === key) {
+      overviewState.sortDirection = overviewState.sortDirection === 'asc' ? 'desc' : 'asc';
+    } else {
+      overviewState.sortKey = key;
+      overviewState.sortDirection = 'asc';
+    }
+    storeOverviewState();
+    renderOverviewFromSnapshot();
+  };
+});
+document.querySelectorAll('[data-overview-filter]').forEach(input => {
+  input.autocomplete = 'off';
+  input.oninput = () => {
+    let key = input.dataset.overviewFilter;
+    if (input.value) overviewState.filters[key] = input.value;
+    else delete overviewState.filters[key];
+    storeOverviewState();
+    renderOverviewFromSnapshot();
+  };
+});
+$('#overviewClearFilters').onclick = () => {
+  overviewState.filters = {};
+  storeOverviewState();
+  renderOverviewFromSnapshot();
+};
+$('#overviewToggle').onclick = () => {
+  overviewState.collapsed = !overviewState.collapsed;
+  storeOverviewState();
+  renderOverviewControls();
+};
 $('#loginBtn').onclick = () => {
   key = $('#key').value.trim();
   rememberKey = $('#rememberKey').checked;
@@ -1515,6 +2166,7 @@ $('#sync').onclick = async () => {
   }
 };
 
+setupOverviewColumnResizers();
 $('#showSpark').checked = showSparkQuota;
 captureStaticText();
 applyLanguage(language);


### PR DESCRIPTION
## Summary

- add a lightweight `GET /v0/management/cpa-quota-estimator/overview` endpoint with current-cycle remaining quota, reset state, Token/USD capacity estimates, confidence, and burn forecast for every sampled account
- merge configured Codex OAuth credentials into the dashboard through an exact, read-only `auth-files` CPAMP bridge that forwards only a small non-secret metadata allowlist
- show sampled and awaiting-first-request accounts together without issuing upstream AI requests, and distinguish active, exhausted, stale-reset, and insufficient-sample states
- add per-column filtering, type-aware sorting, collapsible persisted state, and accessible resizable columns with mouse, keyboard, and reset controls
- document cold-start behavior, the overview API, security boundary, and UI controls in English and Chinese; bump the candidate version to `0.5.0`

## Security and behavior

- the auth inventory bridge accepts only an exact same-origin `GET /v0/management/auth-files` request from this plugin
- the parent trims every auth record to identifier/name, provider/type, plan metadata, and disabled/unavailable flags; it does not forward tokens, secrets, project metadata, or the Management Key
- loading, filtering, sorting, resizing, or selecting overview rows does not make an AI model request
- Spark quota remains opt-in and isolated from the primary quota accounting

## Validation

- `go test -count=1 ./...`
- `go vet ./...`
- `git diff --check`
- Linux CGO shared-library builds for amd64 and arm64
- isolated Chromium regression coverage for OAuth plan normalization, account merging, filtering, sorting, 40-2000 px column resizing, reset, collapse, persistence, and Chinese/English UI state